### PR TITLE
offset left+top with ace_inner position

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -131,6 +131,12 @@ var showAuthor = {
 
     // TODO use qtip, it will handle edge cases better
     var outBody = $('iframe[name="ace_outer"]').contents().find("body");
+
+    var inFrame = $(outBody).find('iframe[name="ace_inner"]');
+    var inFramePos = inFrame.position();
+    left += inFramePos.left;
+    top += inFramePos.top;
+
     var lt = /</g,
       gt = />/g,
       ap = /'/g,


### PR DESCRIPTION
Offset tooltip position with the position of the ace_inner frame. This fixes the issue where the tooltips would pull far left on wide screens.