### PR TITLE
refactor: adopt template helper for eejsBlock_mySettings (with vars callback)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,12 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const {template} = require('ep_plugin_helpers');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  let checkedState = 'checked';
-  if (settings.ep_author_hover) {
-    if (settings.ep_author_hover.disabledByDefault === true) {
-      checkedState = '';
-    }
-  }
-  args.content += eejs.require('ep_author_hover/templates/settings.ejs', {checked: checkedState});
-  return cb();
-};
+exports.eejsBlock_mySettings = template('ep_author_hover/templates/settings.ejs', {
+  vars: () => ({
+    checked: settings.ep_author_hover &&
+        settings.ep_author_hover.disabledByDefault === true
+      ? '' : 'checked',
+  }),
+});

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.5.0
+        version: 0.5.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -399,6 +403,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.5.2:
+    resolution: {integrity: sha512-6M0gYqRTaF2SnTvV1OiqOZQ4B37ZHL0Zjoz3/eOIAXeCEBA4jId62uz9uboLs87Qcfae7eirDYWpdir5u5zkEQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1672,6 +1680,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.5.2: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
Replaces hand-rolled `eejs.require + cb()` boilerplate with `template(path, {vars: () => ({checked})})` from `ep_plugin_helpers`. The vars callback hosts the `checked` state derivation; same runtime behavior.

Wave 3 of the Phase 4 template-helper sweep — handles the hooks with vars passing that strict-simple wave 1/2 skipped.