### PR TITLE
helpers: adopt padToggle for "Show Author on Hover" setting

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -1,12 +1,17 @@
 {
   "parts": [
-  {
-    "name": "ep_author_hover",
-    "hooks" : {
-      "eejsBlock_mySettings": "ep_author_hover/index"
-    },
-    "client_hooks" : {
-      "postAceInit":"ep_author_hover/static/js/index"
+    {
+      "name": "ep_author_hover",
+      "hooks": {
+        "loadSettings": "ep_author_hover/index",
+        "clientVars": "ep_author_hover/index",
+        "eejsBlock_mySettings": "ep_author_hover/index",
+        "eejsBlock_padSettings": "ep_author_hover/index"
+      },
+      "client_hooks": {
+        "postAceInit": "ep_author_hover/static/js/index",
+        "handleClientMessage_CLIENT_MESSAGE": "ep_author_hover/static/js/index:handleClientMessage_CLIENT_MESSAGE"
+      }
     }
-  }]
+  ]
 }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,29 @@
 'use strict';
 
-const {template} = require('ep_plugin_helpers');
-const settings = require('ep_etherpad-lite/node/utils/Settings');
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
-exports.eejsBlock_mySettings = template('ep_author_hover/templates/settings.ejs', {
-  vars: () => ({
-    checked: settings.ep_author_hover &&
-        settings.ep_author_hover.disabledByDefault === true
-      ? '' : 'checked',
-  }),
+// Parallel User Settings + Pad Wide Settings checkboxes for "Show Author on
+// Hover". Helper owns markup, storage, broadcast, enforce, and i18n wiring.
+const authorHoverToggle = padToggle({
+  pluginName: 'ep_author_hover',
+  settingId: 'author-hover',
+  l10nId: 'ep_author_hover.showHoverLabel',
+  defaultLabel: 'Show Author on Hover',
+  defaultEnabled: true,
 });
+
+// Older settings.json used `ep_author_hover.disabledByDefault: true` to flip
+// the checkbox off. Translate to the helper's `defaultEnabled` so existing
+// installs keep their current behavior after the conversion.
+exports.loadSettings = async (hookName, args) => {
+  const ps = args && args.settings && args.settings.ep_author_hover;
+  if (ps && typeof ps.defaultEnabled !== 'boolean' &&
+      typeof ps.disabledByDefault === 'boolean') {
+    ps.defaultEnabled = !ps.disabledByDefault;
+  }
+  return authorHoverToggle.loadSettings(hookName, args);
+};
+
+exports.clientVars = authorHoverToggle.clientVars;
+exports.eejsBlock_mySettings = authorHoverToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = authorHoverToggle.eejsBlock_padSettings;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.5.0"
+    "ep_plugin_helpers": "^0.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       ep_plugin_helpers:
-        specifier: ^0.5.0
+        specifier: ^0.5.2
         version: 0.5.2
     devDependencies:
       eslint:

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,19 +1,35 @@
 'use strict';
 
-const padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
-import html10n from 'ep_etherpad-lite/static/js/vendors/html10n'
+// Sub-path import keeps the client bundle clean — the top-level
+// `ep_plugin_helpers` index pulls in server-only modules.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
+import html10n from 'ep_etherpad-lite/static/js/vendors/html10n';
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, l10nId, and defaultLabel so checkbox ids and clientVars line up.
+const authorHoverToggle = padToggle({
+  pluginName: 'ep_author_hover',
+  settingId: 'author-hover',
+  l10nId: 'ep_author_hover.showHoverLabel',
+  defaultLabel: 'Show Author on Hover',
+  defaultEnabled: true,
+});
+
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = authorHoverToggle.handleClientMessage_CLIENT_MESSAGE;
 
 let timer = 0;
 
 const showAuthor = {
   enable: () => {
     $('iframe[name="ace_outer"]').contents().find('iframe')
-      .contents().find('#innerdocbody').on('mousemove',exports.showAuthor.hover);
+        .contents().find('#innerdocbody').on('mousemove', exports.showAuthor.hover);
   },
   disable: (context) => {
     context.ace.callWithAce((ace) => {
       const doc = ace.ace_getDocument();
-      $(doc).find('#innerdocbody').on('mousemove',null.bind(ace));
+      $(doc).find('#innerdocbody').on('mousemove', null.bind(ace));
     }, 'showAuthor', true);
   },
   hover: (span) => {
@@ -33,7 +49,7 @@ const showAuthor = {
       if (!authorId) { return; } // Default text isn't shown
       showAuthor.destroy(); // Destroy existing
       const authorNameAndColor =
-        showAuthor.authorNameAndColorFromAuthorId(authorId); // Get the authorName And Color
+          showAuthor.authorNameAndColorFromAuthorId(authorId);
       showAuthor.draw(span, authorNameAndColor.name, authorNameAndColor.color);
     }
   },
@@ -133,27 +149,17 @@ const showAuthor = {
 
 exports.postAceInit = (hookName, context) => {
   showAuthor.enable(context);
-  clientVars.plugins.plugins.ep_author_hover = {};
-  /* init */
-  if (padcookie.getPref('author-hover') === false) {
-    $('#options-author-hover').val();
-    $('#options-author-hover').prop('checked', false);
-    $('#options-author-hover').prop('checked', false);
-  } else {
-    $('#options-author-hover').prop('checked', true);
+  // Pre-existing public API: showAuthor.show() reads
+  // clientVars.plugins.plugins.ep_author_hover.enabled on every hover. Keep
+  // the field populated as the toggle changes so external integrations
+  // (and our own show() code) see the live state without rewiring.
+  if (!clientVars.plugins.plugins.ep_author_hover) {
+    clientVars.plugins.plugins.ep_author_hover = {};
   }
-
-  clientVars.plugins.plugins.ep_author_hover.enabled = !!$('#options-author-hover').is(':checked');
-
-  /* on click */
-  $('#options-author-hover').on('click', () => {
-    if ($('#options-author-hover').is(':checked')) {
-      clientVars.plugins.plugins.ep_author_hover.enabled = true;
-      padcookie.setPref('author-hover', true);
-    } else {
-      padcookie.setPref('author-hover', false);
-      clientVars.plugins.plugins.ep_author_hover.enabled = false;
-    }
+  authorHoverToggle.init({
+    onChange: (enabled) => {
+      clientVars.plugins.plugins.ep_author_hover.enabled = enabled;
+    },
   });
 };
 

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -1,6 +1,0 @@
-<p>
-    <input type="checkbox" id="options-author-hover" checked></input>
-    <label for="options-author-hover" data-l10n-id="ep_author_hover.showHoverLabel">
-      Show Author on Hover
-    </label>
-</p>


### PR DESCRIPTION
## Summary

- Replace the manual `eejsBlock_mySettings` template + cookie wiring with `padToggle` from `ep_plugin_helpers`. Parallel User Settings / Pad Wide Settings checkboxes for free; helper owns markup, storage, broadcast, enforce, and i18n.
- Slim `static/js/index.js` to use `padToggle.init({onChange})` instead of hand-rolled cookie restore + click binding.
- Preserve `clientVars.plugins.plugins.ep_author_hover.enabled` — `showAuthor.show()` reads it on every hover, so the `onChange` callback keeps that field populated as the toggle changes. No rewiring of consumers needed.
- Translate legacy `ep_author_hover.disabledByDefault: true` to the helper's `defaultEnabled` in `loadSettings` so existing installs keep their current behavior.
- Drop `templates/settings.ejs` — helper renders markup itself.

## Test plan

- [x] Server-side smoke test (Node): module loads, exports the four hooks, `eejsBlock_mySettings` produces valid `<input>`/`<label>` markup with `data-l10n-id`, legacy `disabledByDefault: true` translates to `defaultEnabled: false`.
- [ ] CI green (backend + frontend tests)
- [ ] In a pad: hover shows author popup. Untick "Show Author on Hover" in User Settings — popup stops appearing. Re-tick — popup returns.
- [ ] On a core that supports pad-wide passthrough (Etherpad ≥ 2.7.4 + `enablePluginPadOptions: true`): toggling Pad Wide Settings broadcasts to other users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)