### PR TITLE
fix: show no tooltip for text the reserved system author holds

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -21,6 +21,15 @@ exports.handleClientMessage_CLIENT_MESSAGE = authorHoverToggle.handleClientMessa
 
 let timer = 0;
 
+// Etherpad attributes inserts to this reserved id when no real author made
+// them: the default pad content written on pad creation, HTTP API
+// setText/appendText/setHTML calls without an authorId, server-side imports.
+// It is changeset bookkeeping rather than a contributor — core deliberately
+// keeps it out of historicalAuthorData and listAuthorsOfPad — so hovering
+// such text fell through to "Unknown Author". Nobody wrote it, so show
+// nothing at all. See ether/etherpad#8044.
+const SYSTEM_AUTHOR_ID = 'a.etherpad-system';
+
 const showAuthor = {
   enable: () => {
     $('iframe[name="ace_outer"]').contents().find('iframe')
@@ -47,6 +56,7 @@ const showAuthor = {
       if (!authorTarget) { return; } // We might not be over a valid target
       const authorId = showAuthor.authorIdFromClass(authorTarget.className); // Get the authorId
       if (!authorId) { return; } // Default text isn't shown
+      if (authorId === SYSTEM_AUTHOR_ID) { return; } // Not written by anyone
       showAuthor.destroy(); // Destroy existing
       const authorNameAndColor =
           showAuthor.authorNameAndColorFromAuthorId(authorId);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -56,8 +56,13 @@ const showAuthor = {
       if (!authorTarget) { return; } // We might not be over a valid target
       const authorId = showAuthor.authorIdFromClass(authorTarget.className); // Get the authorId
       if (!authorId) { return; } // Default text isn't shown
-      if (authorId === SYSTEM_AUTHOR_ID) { return; } // Not written by anyone
+      // Clear any still-visible tooltip from the previous hover BEFORE the
+      // system-author bail-out below: tooltips linger for ~1.2s while they
+      // fade, so returning early without destroying would leave the previous
+      // author's label on screen while the pointer sits over text nobody
+      // wrote.
       showAuthor.destroy(); // Destroy existing
+      if (authorId === SYSTEM_AUTHOR_ID) { return; } // Not written by anyone
       const authorNameAndColor =
           showAuthor.authorNameAndColorFromAuthorId(authorId);
       showAuthor.draw(span, authorNameAndColor.name, authorNameAndColor.color);

--- a/static/tests/frontend-new/specs/author_hover.spec.ts
+++ b/static/tests/frontend-new/specs/author_hover.spec.ts
@@ -1,5 +1,10 @@
 import {expect, test} from '@playwright/test';
-import {goToNewPad} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
+import {
+  getPadBody,
+  getPadOuter,
+  goToNewPad,
+  writeToPad,
+} from 'ep_etherpad-lite/tests/frontend-new/helper/padHelper';
 
 test.beforeEach(async ({page}) => {
   await goToNewPad(page);
@@ -36,5 +41,37 @@ test.describe('ep_author_hover', () => {
     // hook; its checkbox is identified by id="options-author-hover".
     await expect(page.locator('#options-author-hover')).toBeAttached();
     await expect(page.locator('label[for="options-author-hover"]')).toBeAttached();
+  });
+
+  // The tooltip is drawn 1s after the mousemove and fades out ~1.2s later, so
+  // poll for it rather than sampling at a fixed instant.
+  const tooltipTextAfterHover = async (
+    page: import('@playwright/test').Page,
+    target: import('@playwright/test').Locator,
+  ): Promise<string|null> => {
+    await target.hover();
+    const tooltip = (await getPadOuter(page)).locator('.authortooltip');
+    for (let i = 0; i < 40; i++) {
+      if (await tooltip.count()) return (await tooltip.first().innerText()).trim();
+      await page.waitForTimeout(100);
+    }
+    return null;
+  };
+
+  test('shows a tooltip over your own writing', async ({page}) => {
+    const body = await getPadBody(page);
+    await writeToPad(page, 'MYTEXT');
+    const mine = body.locator('span').filter({hasText: 'MYTEXT'}).first();
+    expect(await tooltipTextAfterHover(page, mine)).not.toBeNull();
+  });
+
+  test('shows no tooltip over text the system author holds', async ({page}) => {
+    // The default pad content is attributed to `a.etherpad-system` — nobody
+    // wrote it, and core ships no author record for that id, so the lookup
+    // used to fall through to "Unknown Author" (ether/etherpad#8044).
+    const body = await getPadBody(page);
+    const defaultText = body.locator('span.author-a-etherpadz45zsystem').first();
+    await expect(defaultText).toBeAttached();
+    expect(await tooltipTextAfterHover(page, defaultText)).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up to ether/etherpad#8044 / ether/etherpad#8090, on the plugin side.

## Problem

`a.etherpad-system` is the reserved id Etherpad attributes inserts to when no real author made them: the default pad content written on pad creation, HTTP API `setText`/`appendText`/`setHTML` without an `authorId`, and server-side imports. It's changeset bookkeeping, not a contributor — core ships no `globalAuthor:` record for it and filters it out of `historicalAuthorData` and `listAuthorsOfPad`.

So hovering the welcome text on any fresh pad fell through every lookup (not me → not in the user list → not in `historicalAuthorData`) and landed on the "Unknown Author" fallback. Verified in a browser before the fix — the tooltip reads **UNKNOWN AUTHOR**.

## Fix

Return early in `show()` when the hovered span belongs to the system author. Nobody wrote that text, so no tooltip is better than naming an unknown someone.

## Tests

Two new Playwright specs:
- a tooltip still appears over your own writing (guards against the early return being too broad);
- no tooltip appears over system-authored text.

The second one fails on the pre-fix build with `Received: "UNKNOWN AUTHOR"` and passes after. Both were run against a local Etherpad with this branch installed — 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)